### PR TITLE
fix(install): use Python Launcher for pipx installation

### DIFF
--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -28,20 +28,6 @@ export HISTFILE=~/.bash_history
 # Alias for a 2-level directory tree view, ignoring .git.
 alias llt='tree -a -L 2 -I .git'
 
-# -----------------------------------------------------------------
-# SECTION 2: CUSTOM WINDOWS PATH CONFIGURATION
-# -----------------------------------------------------------------
-# Manually add required user-level script paths for Python tools
-# to ensure they are discoverable in the shell.
-
-# Add Python (N-version) user-level scripts (for 'pipx').
-export PATH="$PATH:$HOME/AppData/Roaming/Python/Python314/Scripts"
-
-# Add Poetry (official installer) bin path.
-export PATH="$PATH:$HOME/AppData/Roaming/pypoetry/bin"
-
-# Add pipx global tool bin path (managed by 'pipx ensurepath').
-export PATH="$PATH:$HOME/.local/bin"
 
 # User-Defined GitHub CLI Aliases
 # Persistent aliases for custom metrics and issue retrieval.


### PR DESCRIPTION
## Changes
- Replaced `python.exe` with `py -3` for pipx installation
- Ensures pipx always installs to system Python, not Poetry's venv
- Removed brittle PATH configuration from .bash_profile
- Tools now rely on Registry PATH updates from their installers

## Root Cause
Poetry's venv Python was appearing first in PATH, causing pipx to attempt installation into Poetry's isolated environment instead of system Python.

## Testing
- [x] pipx installs successfully without errors
- [x] Both `where pipx` and `where poetry` resolve correctly
- [x] No manual PATH configuration needed in .bash_profile

Closes #9