### PR TITLE
fix: Resolve relative path error in sync script

### DIFF
--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -2,7 +2,7 @@
 # AUTOMATIC SYNC: Check for changes in the live file before loading.
 if ! diff -q ~/.bash_profile home/.bash_profile > /dev/null 2>&1; then
     echo "SYNC: Changes detected in ~/.bash_profile. Synchronizing to Git source..." >&2
-    cp ~/.bash_profile home/.bash_profile
+    cp ~/.bash_profile "$HOME/Projects/dotfiles/home/.bash_profile"
 fi
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
Closes #15. Updates the sync logic in .bash_profile to use an absolute path, preventing 'No such file' errors during terminal startup.