### PR TITLE
chore: promote c-28 to prod, c-29 to alpha (#36)

### DIFF
--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -130,8 +130,9 @@ unleashed-beta() {
 unleashed-alpha() {
   local project_path
   project_path="$(cygpath -w "$(pwd)")"
+  local _py="/c/Users/mcwiz/AppData/Local/pypoetry/Cache/virtualenvs/unleashed-dvqmcGZk-py3.14/Scripts/python.exe"
   _unleashed_log "src/unleashed-c-27.py" "$project_path"
-  PYTHONPATH="C:/Users/mcwiz/Projects/unleashed/src" python /c/Users/mcwiz/Projects/unleashed/src/unleashed-c-27.py --cwd "$project_path" --sentinel-shadow --mirror --friction "$@"
+  PYTHONPATH="C:/Users/mcwiz/Projects/unleashed/src" "$_py" /c/Users/mcwiz/Projects/unleashed/src/unleashed-c-27.py --cwd "$project_path" --sentinel-shadow --mirror --friction "$@"
 }
 
 # --- Gemini tier system ---

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -90,8 +90,8 @@ sentinel() {
 }
 
 # UNLEASHED - Tier System (prod / beta / alpha)
-# Mapping: prod=c-24, beta=(none), alpha=c-25
-# Last promotion: 2026-02-23 prod←c-24 (auto-tab-naming)
+# Mapping: prod=c-26, beta=(none), alpha=(none)
+# Last promotion: 2026-03-15 prod←c-26 (per-repo logs, tab focus-back, console tab)
 # See: https://github.com/martymcenroe/unleashed/wiki/Version-Promotions
 
 _unleashed_log() {
@@ -119,7 +119,7 @@ _unleashed_run() {
 }
 
 unleashed() {
-  _unleashed_run src/unleashed-c-25.py --sentinel-shadow --mirror --friction "$@"
+  _unleashed_run src/unleashed-c-26.py --sentinel-shadow --mirror --friction "$@"
 }
 
 unleashed-beta() {
@@ -128,7 +128,8 @@ unleashed-beta() {
 }
 
 unleashed-alpha() {
-  _unleashed_run src/unleashed-c-26.py --sentinel-shadow --mirror --friction "$@"
+  echo "No alpha version configured. Promote a new build with: create new version → unleashed-alpha"
+  return 1
 }
 
 # --- Gemini tier system ---

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -124,7 +124,7 @@ _unleashed_run() {
 }
 
 unleashed() {
-  _unleashed_run src/unleashed-c-27.py --sentinel-shadow --mirror --friction "$@"
+  _unleashed_run src/unleashed-c-28.py --sentinel-shadow --mirror --friction "$@"
 }
 
 unleashed-beta() {
@@ -133,7 +133,7 @@ unleashed-beta() {
 }
 
 unleashed-alpha() {
-  _unleashed_run src/unleashed-c-28.py --sentinel-shadow --mirror --friction "$@"
+  _unleashed_run src/unleashed-c-29.py --sentinel-shadow --mirror --friction "$@"
 }
 
 # --- Gemini tier system ---

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -128,7 +128,10 @@ unleashed-beta() {
 }
 
 unleashed-alpha() {
-  _unleashed_run src/unleashed-c-27.py --sentinel-shadow --mirror --friction "$@"
+  local project_path
+  project_path="$(cygpath -w "$(pwd)")"
+  _unleashed_log "src/unleashed-c-27.py" "$project_path"
+  PYTHONPATH="C:/Users/mcwiz/Projects/unleashed/src" python /c/Users/mcwiz/Projects/unleashed/src/unleashed-c-27.py --cwd "$project_path" --sentinel-shadow --mirror --friction "$@"
 }
 
 # --- Gemini tier system ---

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -128,8 +128,7 @@ unleashed-beta() {
 }
 
 unleashed-alpha() {
-  echo "No alpha version configured. Promote a new build with: create new version → unleashed-alpha"
-  return 1
+  _unleashed_run src/unleashed-c-27.py --sentinel-shadow --mirror --friction "$@"
 }
 
 # --- Gemini tier system ---

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -139,7 +139,15 @@ unleashed-g() {
 }
 
 unleashed-t() {
-  _unleashed_run src/unleashed-t-01.py "$@"
+  local repo_root="/c/Users/mcwiz/Projects/unleashed"
+  local script="src/unleashed-t-01.py"
+  if [ ! -f "$repo_root/$script" ] && [ -f /c/Users/mcwiz/Projects/unleashed-56/$script ]; then
+    repo_root="/c/Users/mcwiz/Projects/unleashed-56"
+  fi
+  local project_path
+  project_path="$(cygpath -w "$(pwd)")"
+  _unleashed_log "$script" "$project_path"
+  (cd "$repo_root" && poetry run python "$script" --cwd "$project_path" "$@")
 }
 
 # BATCH WORKFLOW - Run multiple issues unattended

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -114,9 +114,13 @@ _unleashed_run() {
   local script="$1"; shift
   local project_path
   project_path="$(cygpath -w "$(pwd)")"
-  local _py="/c/Users/mcwiz/AppData/Local/pypoetry/Cache/virtualenvs/unleashed-dvqmcGZk-py3.14/Scripts/python.exe"
+  # Use poetry's active venv python + put its Scripts on PATH so tools like
+  # edge-tts, yt-dlp etc. are available to Claude sessions (was lost when
+  # we dropped poetry run — see #83)
+  local _venv="/c/Users/mcwiz/AppData/Local/pypoetry/Cache/virtualenvs/unleashed-Zukdy2xA-py3.14"
+  local _py="$_venv/Scripts/python.exe"
   _unleashed_log "$script" "$project_path"
-  PYTHONPATH="C:/Users/mcwiz/Projects/unleashed/src" "$_py" /c/Users/mcwiz/Projects/unleashed/"$script" --cwd "$project_path" "$@"
+  PATH="$_venv/Scripts:$PATH" PYTHONPATH="C:/Users/mcwiz/Projects/unleashed/src" "$_py" /c/Users/mcwiz/Projects/unleashed/"$script" --cwd "$project_path" "$@"
 }
 
 unleashed() {

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -134,21 +134,15 @@ unleashed-alpha() {
 }
 
 # --- Gemini tier system ---
-# Prod: g-19 (triplet + 0.2s approval delay + 3 permission patterns)
+# Prod: g-20 (g-19 + console tab, per-repo logs, focus-back, tab-naming)
 unleashed-g() {
-  _unleashed_run src/unleashed-g-19.py "$@"
+  _unleashed_run src/unleashed-g-20.py "$@"
 }
 
+# --- Codex tier system ---
+# Prod: t-02 (t-01 + console tab, per-repo logs, focus-back)
 unleashed-t() {
-  local repo_root="/c/Users/mcwiz/Projects/unleashed"
-  local script="src/unleashed-t-01.py"
-  if [ ! -f "$repo_root/$script" ] && [ -f /c/Users/mcwiz/Projects/unleashed-56/$script ]; then
-    repo_root="/c/Users/mcwiz/Projects/unleashed-56"
-  fi
-  local project_path
-  project_path="$(cygpath -w "$(pwd)")"
-  _unleashed_log "$script" "$project_path"
-  (cd "$repo_root" && poetry run python "$script" --cwd "$project_path" "$@")
+  _unleashed_run src/unleashed-t-02.py "$@"
 }
 
 # BATCH WORKFLOW - Run multiple issues unattended

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -138,6 +138,10 @@ unleashed-g() {
   _unleashed_run src/unleashed-g-19.py "$@"
 }
 
+unleashed-t() {
+  _unleashed_run src/unleashed-t-01.py "$@"
+}
+
 # BATCH WORKFLOW - Run multiple issues unattended
 alias batch-workflow='/c/Users/mcwiz/Projects/AssemblyZero/tools/batch-workflow.sh'
 

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -128,8 +128,7 @@ unleashed-beta() {
 }
 
 unleashed-alpha() {
-  echo "No alpha version configured. Promote a new build with: create new version → unleashed-alpha"
-  return 1
+  _unleashed_run src/unleashed-c-26.py --sentinel-shadow --mirror --friction "$@"
 }
 
 # --- Gemini tier system ---

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -90,8 +90,8 @@ sentinel() {
 }
 
 # UNLEASHED - Tier System (prod / beta / alpha)
-# Mapping: prod=c-26, beta=(none), alpha=(none)
-# Last promotion: 2026-03-15 prod←c-26 (per-repo logs, tab focus-back, console tab)
+# Mapping: prod=c-28, beta=c-27, alpha=(none)
+# Last promotion: 2026-03-16 prod←c-28 (auto-handoff: compaction trigger + timer reminder)
 # See: https://github.com/martymcenroe/unleashed/wiki/Version-Promotions
 
 _unleashed_log() {
@@ -124,12 +124,11 @@ _unleashed_run() {
 }
 
 unleashed() {
-  _unleashed_run src/unleashed-c-27.py --sentinel-shadow --mirror --friction "$@"
+  _unleashed_run src/unleashed-c-28.py --sentinel-shadow --mirror --friction "$@"
 }
 
 unleashed-beta() {
-  echo "No beta version configured. Promote a new build with: unleashed-alpha → unleashed-beta"
-  return 1
+  _unleashed_run src/unleashed-c-27.py --sentinel-shadow --mirror --friction "$@"
 }
 
 unleashed-alpha() {

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -114,12 +114,13 @@ _unleashed_run() {
   local script="$1"; shift
   local project_path
   project_path="$(cygpath -w "$(pwd)")"
+  local _py="/c/Users/mcwiz/AppData/Local/pypoetry/Cache/virtualenvs/unleashed-dvqmcGZk-py3.14/Scripts/python.exe"
   _unleashed_log "$script" "$project_path"
-  (cd /c/Users/mcwiz/Projects/unleashed && poetry run python "$script" --cwd "$project_path" "$@")
+  PYTHONPATH="C:/Users/mcwiz/Projects/unleashed/src" "$_py" /c/Users/mcwiz/Projects/unleashed/"$script" --cwd "$project_path" "$@"
 }
 
 unleashed() {
-  _unleashed_run src/unleashed-c-26.py --sentinel-shadow --mirror --friction "$@"
+  _unleashed_run src/unleashed-c-27.py --sentinel-shadow --mirror --friction "$@"
 }
 
 unleashed-beta() {
@@ -128,11 +129,8 @@ unleashed-beta() {
 }
 
 unleashed-alpha() {
-  local project_path
-  project_path="$(cygpath -w "$(pwd)")"
-  local _py="/c/Users/mcwiz/AppData/Local/pypoetry/Cache/virtualenvs/unleashed-dvqmcGZk-py3.14/Scripts/python.exe"
-  _unleashed_log "src/unleashed-c-27.py" "$project_path"
-  PYTHONPATH="C:/Users/mcwiz/Projects/unleashed/src" "$_py" /c/Users/mcwiz/Projects/unleashed/src/unleashed-c-27.py --cwd "$project_path" --sentinel-shadow --mirror --friction "$@"
+  echo "No alpha version configured. Promote a new build with: create new version → unleashed-alpha"
+  return 1
 }
 
 # --- Gemini tier system ---

--- a/home/.bash_profile
+++ b/home/.bash_profile
@@ -90,8 +90,8 @@ sentinel() {
 }
 
 # UNLEASHED - Tier System (prod / beta / alpha)
-# Mapping: prod=c-28, beta=c-27, alpha=(none)
-# Last promotion: 2026-03-16 prod←c-28 (auto-handoff: compaction trigger + timer reminder)
+# Mapping: prod=c-27, beta=(none), alpha=c-28
+# Last promotion: 2026-03-16 alpha←c-28 (auto-handoff: compaction trigger + timer reminder)
 # See: https://github.com/martymcenroe/unleashed/wiki/Version-Promotions
 
 _unleashed_log() {
@@ -124,16 +124,16 @@ _unleashed_run() {
 }
 
 unleashed() {
-  _unleashed_run src/unleashed-c-28.py --sentinel-shadow --mirror --friction "$@"
-}
-
-unleashed-beta() {
   _unleashed_run src/unleashed-c-27.py --sentinel-shadow --mirror --friction "$@"
 }
 
-unleashed-alpha() {
-  echo "No alpha version configured. Promote a new build with: create new version → unleashed-alpha"
+unleashed-beta() {
+  echo "No beta version configured. Promote a new build with: unleashed-alpha → unleashed-beta"
   return 1
+}
+
+unleashed-alpha() {
+  _unleashed_run src/unleashed-c-28.py --sentinel-shadow --mirror --friction "$@"
 }
 
 # --- Gemini tier system ---


### PR DESCRIPTION
Closes #36

## Summary
- `unleashed()` → c-28 (was c-27) — promoted after alpha testing validated companion cleanup, per-repo logs, auto-config
- `unleashed-alpha()` → c-29 (was c-28) — fixes timer reminder TUI collision (unleashed #102)