### PR TITLE
chore: remove orphaned gh CLI aliases from common/.bash_profile

### DIFF
--- a/common/.bash_profile
+++ b/common/.bash_profile
@@ -43,8 +43,3 @@ alias llt='tree -a -L 2 -I .git'
 
 # Add pipx global tool bin path (managed by 'pipx ensurepath').
 export PATH="$PATH:$HOME/.local/bin"
-
-# User-Defined GitHub CLI Aliases
-# Persistent aliases for custom metrics and issue retrieval.
-alias gh-count='gh search commits --author martymcenroe --author-date ">=$(date -u +%Y-%m-%d)" | wc -l'
-alias gh-issue-list="gh issue list --json number,title,body --template '{{range .}}### Issue #{{.number}}: {{.title}}\n\nBody:\n---\n{{.body}}\n---\n\n\n{{end}}'"


### PR DESCRIPTION
Closes martymcenroe/AssemblyZero#1245

## Problem

`common/.bash_profile` contained two shell aliases that were never loaded by any shell:

```bash
alias gh-count='gh search commits --author martymcenroe ...'
alias gh-issue-list="gh issue list --json ..."
```

Nothing sources `common/.bash_profile`. The active sync target is `home/.bash_profile` (synced from `~/.bash_profile` on every shell startup via SECTION 0 of `~/.bash_profile`). These aliases sat as dead code.

The operator had been thinking `gh-count` worked as a shell alias when in fact the working `gh-count` is a **`gh` CLI alias** (different mechanism), configured via `gh alias set`, persisted to `~/.config/gh/config.yml`, and invoked as `gh gh-count`. Same name, completely different system. The shell alias in `common/` was orphaned legacy.

`type gh-count` returns `not found` in any login shell — confirms the orphans never load.

## Change

Removed lines 47–50 of `common/.bash_profile` (the comment block + two alias definitions). Five lines deleted; no other changes.

## Verification

```bash
# Before: file ends with the orphan aliases
$ tail -5 common/.bash_profile
... aliases ...

# After: file ends with the pipx PATH line
$ tail -3 common/.bash_profile
# Add pipx global tool bin path (managed by 'pipx ensurepath').
export PATH="$PATH:$HOME/.local/bin"

# The actual working gh-count remains live:
$ gh gh-count
GitHub Contributions for 2026-05-24: ...
```

## Cross-repo context

- AssemblyZero#1245 — the tracking issue, will auto-close on merge
- AssemblyZero/docs/runbooks/0936-gh-cli-aliases.md — documents this divergence trap as a permanent lesson so a future operator doesn't re-add orphans without realizing nothing sources the file