### PR TITLE
fix: make install.sh genuinely idempotent; drop Python 3.13 (Closes #51)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,28 +1,59 @@
 #!/bin/bash
-# This script performs a full, idempotent setup of a Windows 11
-# development environment.
+# Idempotent setup of a Windows 11 development environment.
+#
+# IDEMPOTENT MEANS IDEMPOTENT. `winget install <id>` on an already-present
+# package RE-RUNS the installer -- that is NOT a no-op: it can throw an
+# unknown-publisher/UAC prompt (GnuWin32 packages are unsigned), change the
+# installed version, or pull in co-packages. `code --install-extension --force`
+# likewise re-installs every extension on every run. So this script now PROBES
+# for each thing first -- presence, and version where it matters -- and skips
+# what is already satisfied. It changes nothing it does not have to.
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# wgi <winget-id> <probe> [<dir-to-test-instead-of-command>]
+# If <dir> is given, presence is tested by that directory existing (for GUI
+# apps like Sublime that do not put a command on PATH). Otherwise by command.
+wgi() {
+  local id="$1" probe="$2" dir="${3:-}"
+  if [ -n "$dir" ]; then
+    if [ -e "$dir" ]; then echo "  [skip] $id present ($dir)"; return; fi
+  elif have "$probe"; then
+    echo "  [skip] $probe present ($("$probe" --version 2>/dev/null | head -1))"; return
+  fi
+  echo "  [install] $id ..."
+  winget install --id "$id" -e --source winget \
+    --accept-source-agreements --accept-package-agreements
+}
 
 # -----------------------------------------------------------------
-# SECTION 1: CORE APPLICATION INSTALLATION (WINGET)
+# SECTION 1: CORE APPLICATION INSTALLATION (WINGET) -- probe-first
 # -----------------------------------------------------------------
-echo "--- Installing Core Applications (winget) ---"
-winget install --id Git.Git -e --source winget
-winget install --id GnuWin32.Tree -e --source winget
-winget install --id Microsoft.VisualStudioCode -e --source winget
-winget install --id GitHub.cli -e --source winget
-winget install --id jqlang.jq -e --source winget
-winget install --id Sublime.SublimeText -e --source winget
+echo "--- Core Applications (winget, idempotent) ---"
+wgi Git.Git                    git
+wgi GnuWin32.Tree              tree "/c/Program Files (x86)/GnuWin32/bin/tree.exe"
+wgi Microsoft.VisualStudioCode code
+wgi GitHub.cli                 gh
+wgi jqlang.jq                  jq
+wgi Sublime.SublimeText        subl "/c/Program Files/Sublime Text"
 
-# Install "N" and "N-1" Python versions (N-2 Policy)
-# This establishes our base interpreters.
-winget install --id Python.Python.3.14 -e --silent
-winget install --id Python.Python.3.13 -e --silent
+# Python 3.14 only. The old "N and N-1" line also installed Python 3.13 --
+# removed: the fleet is pinned to 3.14 (the unleashed poetry venv path is
+# version-locked to py3.14, and a stray 3.13 shadows resolution and litters
+# PATH/registry/Start-Menu). See comp-environ #37. Probe by VERSION, not by
+# bare `python`, which the Windows Store stub or any 3.x would satisfy.
+if py -3.14 --version 2>/dev/null | grep -q "^Python 3\.14"; then
+  echo "  [skip] Python 3.14 present ($(py -3.14 --version 2>/dev/null))"
+else
+  echo "  [install] Python.Python.3.14 ..."
+  winget install --id Python.Python.3.14 -e --silent \
+    --accept-source-agreements --accept-package-agreements
+fi
 
-# Install Java Runtime (JRE) for SonarLint
-# This is a required dependency for the SonarLint VSCode extension.
-winget install --id EclipseAdoptium.Temurin.17.JRE -e --silent
+# Java Runtime (JRE) for the SonarLint VSCode extension.
+wgi EclipseAdoptium.Temurin.17.JRE java
 
-echo "✅ Core applications installed."
+echo "Core applications checked."
 echo ""
 
 # -----------------------------------------------------------------
@@ -62,13 +93,24 @@ EXTENSIONS=(
     "Redis.redis-for-vscode" # FIX: 'ms-azuretools.vscode-redis' is stale.
 )
 
-# Loop and install each extension.
-for EXTENSION in "${EXTENSIONS[@]}"; do
-    echo "Installing $EXTENSION..."
-    # --force ensures it updates if already installed
-    code --install-extension "$EXTENSION" --force
-done
-echo "✅ VSCode Extensions installed."
+# Install only the extensions NOT already present. The old loop used
+# `--install-extension --force` on every entry every run -- that re-installs
+# all 22 extensions each time (slow, network-heavy, and not idempotent). Ask
+# VSCode what it already has, once, and install only the gaps.
+if have code; then
+  INSTALLED="$(code --list-extensions 2>/dev/null | tr '[:upper:]' '[:lower:]')"
+  for EXTENSION in "${EXTENSIONS[@]}"; do
+    if echo "$INSTALLED" | grep -qxF "$(echo "$EXTENSION" | tr '[:upper:]' '[:lower:]')"; then
+      echo "  [skip] $EXTENSION"
+    else
+      echo "  [install] $EXTENSION"
+      code --install-extension "$EXTENSION"
+    fi
+  done
+  echo "VSCode extensions checked."
+else
+  echo "  [warn] 'code' not on PATH -- skipping extensions (open VSCode once, re-run)"
+fi
 echo ""
 
 # -----------------------------------------------------------------
@@ -76,16 +118,17 @@ echo ""
 # -----------------------------------------------------------------
 echo "--- Configuring Python Tooling ---"
 
-echo "Installing pipx (Global Tool Manager) into 'N' Python..."
-# This installs pipx into the user-level scripts of the 'N'
-# version (3.14), as per our "rolling" architecture.
-# We use Python Launcher 'py -3' which always finds the latest system Python,
-# not 'python.exe' which can resolve to Poetry's venv after first run.
-py -3 -m pip install --user pipx
-
-echo "Bootstrapping pipx: Adding to Windows Registry PATH..."
-# This ensures pipx is on the PATH for all *future* sessions.
-py -3 -m pipx ensurepath
+# pipx -- only if absent. Re-running `pip install --user pipx` every time is
+# another non-idempotent re-do. NOTE: poetry is NOT installed via pipx here
+# (that path fails on Windows -- comp-environ #38); poetry uses its official
+# installer below. pipx is kept only for other global CLI tools.
+if py -3 -m pipx --version >/dev/null 2>&1; then
+  echo "  [skip] pipx present ($(py -3 -m pipx --version 2>/dev/null))"
+else
+  echo "  [install] pipx (into 'N' Python via py -3) ..."
+  py -3 -m pip install --user pipx
+  py -3 -m pipx ensurepath
+fi
 
 echo "Installing Poetry (Project Manager) via official installer..."
 # This uses the mandated official installer, which is independent
@@ -163,21 +206,38 @@ echo "--- Deploying Config Files from Repo --- "
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 echo "Repo source directory is: $SCRIPT_DIR"
 
-# Deploy .bash_profile
+# Deploy .bash_profile. BACK UP any existing one first -- this is a blind
+# overwrite of a file the operator edits by hand, and clobbering it without a
+# copy is how local work disappears. Skip the copy entirely if it is already
+# identical, so a re-run is a true no-op.
 echo "Deploying .bash_profile..."
-cp -v "$SCRIPT_DIR/home/.bash_profile" "$HOME/.bash_profile"
+if [ -f "$HOME/.bash_profile" ] && diff -q "$SCRIPT_DIR/home/.bash_profile" "$HOME/.bash_profile" >/dev/null 2>&1; then
+  echo "  [skip] .bash_profile already current"
+else
+  [ -f "$HOME/.bash_profile" ] && cp "$HOME/.bash_profile" "$HOME/.bash_profile.pre-install-$(date +%Y%m%d-%H%M%S)" \
+    && echo "  backed up existing .bash_profile"
+  cp -v "$SCRIPT_DIR/home/.bash_profile" "$HOME/.bash_profile"
+fi
 
-# Deploy Windows Terminal settings
+# Deploy Windows Terminal settings, same care: back up before overwrite,
+# skip when identical.
 echo "Deploying Windows Terminal settings.json..."
 WT_SETTINGS_DIR="$USERPROFILE/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState"
 mkdir -p "$WT_SETTINGS_DIR"
 if [ -f "$SCRIPT_DIR/windows/terminal/settings.json" ]; then
-  cp -v "$SCRIPT_DIR/windows/terminal/settings.json" "$WT_SETTINGS_DIR/settings.json"
+  if [ -f "$WT_SETTINGS_DIR/settings.json" ] && diff -q "$SCRIPT_DIR/windows/terminal/settings.json" "$WT_SETTINGS_DIR/settings.json" >/dev/null 2>&1; then
+    echo "  [skip] Windows Terminal settings already current"
+  else
+    [ -f "$WT_SETTINGS_DIR/settings.json" ] && cp "$WT_SETTINGS_DIR/settings.json" "$WT_SETTINGS_DIR/settings.json.pre-install-$(date +%Y%m%d-%H%M%S)" \
+      && echo "  backed up existing settings.json"
+    cp -v "$SCRIPT_DIR/windows/terminal/settings.json" "$WT_SETTINGS_DIR/settings.json"
+  fi
 else
   echo "Info: windows/terminal/settings.json not found in repo, skipping."
 fi
 
-echo ""echo "✅ Config file deployment complete."
+echo ""
+echo "Config file deployment complete."
 echo ""
 echo "!!! To apply all PATH changes, either:"
 echo "    1. CLOSE and RE-OPEN your terminal, OR"


### PR DESCRIPTION
Probe presence + version before every install rather than re-running installers blind; install only missing VSCode extensions; guard pipx; remove Python 3.13 (#37); back up config files before overwrite and skip when identical.

Closes #51